### PR TITLE
Add NLP-based figure summarization

### DIFF
--- a/src/scipreprocess/pipeline.py
+++ b/src/scipreprocess/pipeline.py
@@ -17,6 +17,7 @@ from .sectioning import (
     split_into_sections,
     split_into_sections_with_toc,
 )
+from .summarization import summarize_caption
 from .utils import ensure_nltk_resources, load_spacy_model, print_availability_status
 
 
@@ -101,6 +102,8 @@ class PreprocessingPipeline:
         # Extract abstract
         abstract = next((s["text"] for s in sections if s["heading"].lower() == "abstract"), "")
 
+        figures = self._summarize_figures(parsed.metadata.get("figures", []))
+
         return {
             "metadata": {
                 "title": title,
@@ -111,7 +114,7 @@ class PreprocessingPipeline:
             },
             "abstract": abstract,
             "sections": sections,
-            "figures": parsed.metadata.get("figures", []),
+            "figures": figures,
             "tables": parsed.metadata.get("tables", []),
             "equations": parsed.metadata.get("equations", []),
             "references": parsed.metadata.get("references", []),
@@ -198,6 +201,26 @@ class PreprocessingPipeline:
         section_text = " ".join(sec["text"] for sec in sections)
 
         return doc_json, section_text
+
+    def _summarize_figures(self, figures: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+        """Attach concise NLP summaries to figure metadata entries."""
+
+        if not figures:
+            return []
+
+        summarized: list[dict[str, Any]] = []
+        for item in figures:
+            if not isinstance(item, dict):
+                summarized.append(item)
+                continue
+
+            caption = item.get("caption", "")
+            summary = summarize_caption(caption, self.nlp_model)
+            enriched = dict(item)
+            enriched["summary"] = summary
+            summarized.append(enriched)
+
+        return summarized
 
     def preprocess_documents(self, file_paths: list[str], lower: bool = False) -> dict[str, Any]:
         """Preprocess multiple scientific documents.

--- a/src/scipreprocess/summarization.py
+++ b/src/scipreprocess/summarization.py
@@ -108,8 +108,7 @@ def summarize_caption(
         return _trim_to_word_limit(cleaned, max_words)
 
     if len(sentences) == 1:
-        summary = _trim_to_word_limit(sentences[0], max_words)
-        return summary
+        return _trim_to_word_limit(sentences[0], max_words)
 
     caption_tokens = _prepare_tokens(cleaned, nlp_model)
     if not caption_tokens:

--- a/src/scipreprocess/summarization.py
+++ b/src/scipreprocess/summarization.py
@@ -1,0 +1,143 @@
+"""Summarization utilities for short scientific text spans."""
+
+from __future__ import annotations
+
+from collections import Counter
+import re
+from typing import Any, Sequence
+
+from .preprocessing import clean_text, lemmatize, remove_stopwords, sentence_split, tokenize
+
+
+def _basic_tokenize(text: str) -> list[str]:
+    """Lightweight tokenizer that keeps alphabetic tokens only."""
+
+    return [tok for tok in re.findall(r"[A-Za-z][A-Za-z0-9\-']*", text) if tok]
+
+
+def _prepare_tokens(text: str, nlp_model: Any | None = None) -> list[str]:
+    """Tokenize, normalize, and filter tokens for scoring."""
+
+    tokens = tokenize(text, nlp_model)
+    if not tokens and nlp_model is not None:
+        tokens = tokenize(text, None)
+
+    filtered = [tok for tok in tokens if tok and re.search(r"[A-Za-z]", tok)]
+    if not filtered:
+        filtered = _basic_tokenize(text)
+
+    filtered = remove_stopwords(filtered, nlp_model) if filtered else filtered
+    if not filtered and nlp_model is not None:
+        filtered = remove_stopwords(filtered, None)
+
+    if filtered:
+        lemmas = lemmatize(filtered, nlp_model)
+        if not lemmas and nlp_model is not None:
+            lemmas = lemmatize(filtered, None)
+    else:
+        lemmas = []
+
+    normalized = [tok.lower() for tok in lemmas if tok]
+    if not normalized:
+        normalized = [tok.lower() for tok in filtered if tok]
+
+    return normalized
+
+
+def _score_sentences(
+    sentences: Sequence[str], token_weights: Counter[str], nlp_model: Any | None = None
+) -> list[tuple[int, float]]:
+    """Score sentences according to token weights."""
+
+    scores: list[tuple[int, float]] = []
+    for idx, sentence in enumerate(sentences):
+        sent_tokens = _prepare_tokens(sentence, nlp_model)
+        if not sent_tokens:
+            sent_tokens = _basic_tokenize(sentence)
+
+        if not sent_tokens:
+            scores.append((idx, 0.0))
+            continue
+
+        score = sum(token_weights.get(tok, 0) for tok in sent_tokens) / len(sent_tokens)
+        scores.append((idx, score))
+
+    return scores
+
+
+def _trim_to_word_limit(text: str, word_limit: int) -> str:
+    """Trim text to a maximum word length while preserving whole words."""
+
+    if word_limit <= 0:
+        return ""
+
+    words = text.split()
+    if len(words) <= word_limit:
+        return text
+
+    return " ".join(words[:word_limit]) + " ..."
+
+
+def summarize_caption(
+    caption: str,
+    nlp_model: Any | None = None,
+    max_sentences: int = 2,
+    max_words: int = 60,
+) -> str:
+    """Generate a concise summary for a figure caption."""
+
+    if not caption:
+        return ""
+
+    cleaned = clean_text(caption, lower=False)
+    if not cleaned:
+        return ""
+
+    sentences: list[str] = []
+    if nlp_model is not None:
+        try:
+            doc = nlp_model(cleaned)
+            sentences = [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+        except Exception:
+            sentences = []
+
+    if not sentences:
+        sentences = sentence_split(cleaned)
+
+    if not sentences:
+        return _trim_to_word_limit(cleaned, max_words)
+
+    if len(sentences) == 1:
+        summary = _trim_to_word_limit(sentences[0], max_words)
+        return summary
+
+    caption_tokens = _prepare_tokens(cleaned, nlp_model)
+    if not caption_tokens:
+        caption_tokens = _prepare_tokens(cleaned, None)
+
+    token_weights: Counter[str]
+    if caption_tokens:
+        token_weights = Counter(caption_tokens)
+    else:
+        token_weights = Counter(_basic_tokenize(cleaned))
+
+    scored = _score_sentences(sentences, token_weights, nlp_model)
+    scored.sort(key=lambda item: (-item[1], item[0]))
+
+    top_n = min(max_sentences, len(sentences))
+    selected_indices = sorted(idx for idx, _ in scored[:top_n])
+
+    summary_parts = [sentences[idx] for idx in selected_indices]
+    summary = " ".join(summary_parts).strip()
+
+    if not summary:
+        summary = sentences[0]
+
+    summary = _trim_to_word_limit(summary, max_words)
+
+    # Guard against summaries that are longer than the cleaned caption
+    if len(summary) > len(cleaned):
+        summary = _trim_to_word_limit(cleaned, max_words)
+
+    return summary
+

--- a/src/scipreprocess/summarization.py
+++ b/src/scipreprocess/summarization.py
@@ -27,8 +27,6 @@ def _prepare_tokens(text: str, nlp_model: Any | None = None) -> list[str]:
         filtered = _basic_tokenize(text)
 
     filtered = remove_stopwords(filtered, nlp_model) if filtered else filtered
-    if not filtered and nlp_model is not None:
-        filtered = remove_stopwords(filtered, None)
 
     if filtered:
         lemmas = lemmatize(filtered, nlp_model)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from scipreprocess.acronyms import detect_acronyms, expand_acronyms
 from scipreprocess.config import PipelineConfig
+from scipreprocess.models import ParsedDocument
+from scipreprocess.pipeline import PreprocessingPipeline
 from scipreprocess.preprocessing import clean_text, tokenize
 from scipreprocess.sectioning import split_into_sections
 
@@ -82,6 +84,37 @@ def test_split_into_sections():
     assert "Abstract" in headings
     assert "Introduction" in headings
     assert "Methods" in headings
+
+
+def test_pipeline_figures_summary():
+    """Ensure figure summaries are generated and bounded."""
+
+    pipeline = PreprocessingPipeline(PipelineConfig(use_spacy=False))
+    parsed = ParsedDocument(
+        source_path="dummy.pdf",
+        is_scanned=False,
+        text_pages=[""],
+        images=[],
+        metadata={
+            "figures": [
+                {
+                    "type": "figure",
+                    "number": "1",
+                    "caption": (
+                        "Figure 1 illustrates the proposed architecture with three major modules. "
+                        "The framework improves classification accuracy by combining contextual cues."
+                    ),
+                }
+            ]
+        },
+    )
+
+    doc_json = pipeline._assemble_document_json(parsed, "", [], {})
+    figures = doc_json["figures"]
+    assert figures, "Figures should be preserved in the JSON payload"
+    summary = figures[0].get("summary", "")
+    assert summary, "Summaries must not be empty"
+    assert len(summary.split()) <= 60, "Summaries should be length constrained"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a summarization utility that cleans and scores caption text to produce concise figure descriptions
- integrate figure summarization into the preprocessing pipeline so JSON outputs include NLP-generated summaries
- extend pipeline tests to cover the new figure summary behaviour and enforce length constraints

## Testing
- PYTHONPATH=src pytest