### PR TITLE
Add toggle for figure caption summaries

### DIFF
--- a/src/scipreprocess/config.py
+++ b/src/scipreprocess/config.py
@@ -14,6 +14,7 @@ class PipelineConfig:
         use_ocr: Enable OCR for scanned documents (requires pytesseract).
         use_spacy: Use spaCy for NLP tasks (tokenization, lemmatization).
         use_semantic_embeddings: Generate semantic embeddings for chunks.
+        use_figure_summaries: Generate short summaries for figure captions.
         spacy_model: Name of the spaCy model to load.
         embedding_model: Name of the sentence-transformer model.
         chunk_target_sentences: Min and max sentences per chunk.
@@ -23,6 +24,7 @@ class PipelineConfig:
     use_ocr: bool = False
     use_spacy: bool = True
     use_semantic_embeddings: bool = False
+    use_figure_summaries: bool = True
     # Backend selection for parsing; "auto" defaults to local
     parser_backend: str = "auto"
     spacy_model: str = "en_core_web_sm"

--- a/src/scipreprocess/pipeline.py
+++ b/src/scipreprocess/pipeline.py
@@ -20,6 +20,39 @@ from .sectioning import (
 from .utils import ensure_nltk_resources, load_spacy_model, print_availability_status
 
 
+def summarize_caption(caption: str, max_words: int = 40) -> str:
+    """Create a short summary from a figure caption."""
+
+    words = caption.strip().split()
+    if len(words) <= max_words:
+        return caption.strip()
+    return " ".join(words[:max_words]) + "..."
+
+
+def _summarize_figures(
+    figures: list[dict[str, Any]],
+    use_summaries: bool = True,
+) -> list[dict[str, Any]]:
+    """Attach optional summaries to figure metadata."""
+
+    summarized: list[dict[str, Any]] = []
+    for figure in figures:
+        figure_copy: dict[str, Any] = dict(figure)
+
+        if not use_summaries:
+            figure_copy.pop("summary", None)
+            summarized.append(figure_copy)
+            continue
+
+        caption = figure_copy.get("caption")
+        if isinstance(caption, str) and caption.strip():
+            figure_copy["summary"] = summarize_caption(caption)
+
+        summarized.append(figure_copy)
+
+    return summarized
+
+
 class PreprocessingPipeline:
     """Main preprocessing pipeline for scientific documents."""
 
@@ -101,6 +134,11 @@ class PreprocessingPipeline:
         # Extract abstract
         abstract = next((s["text"] for s in sections if s["heading"].lower() == "abstract"), "")
 
+        figures = _summarize_figures(
+            parsed.metadata.get("figures", []),
+            self.config.use_figure_summaries,
+        )
+
         return {
             "metadata": {
                 "title": title,
@@ -111,7 +149,7 @@ class PreprocessingPipeline:
             },
             "abstract": abstract,
             "sections": sections,
-            "figures": parsed.metadata.get("figures", []),
+            "figures": figures,
             "tables": parsed.metadata.get("tables", []),
             "equations": parsed.metadata.get("equations", []),
             "references": parsed.metadata.get("references", []),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,10 +3,12 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import pytest
+
+import scipreprocess.pipeline as pipeline
 
 from scipreprocess.acronyms import detect_acronyms, expand_acronyms
 from scipreprocess.config import PipelineConfig
@@ -84,5 +86,38 @@ def test_split_into_sections():
     assert "Methods" in headings
 
 
+def test_figure_summaries_enabled(monkeypatch):
+    """Ensure figure summaries are generated when enabled."""
+
+    figures = [{"caption": "This figure shows a very detailed experiment."}]
+
+    summary_text = "short summary"
+
+    def fake_summarize(caption: str) -> str:
+        fake_summarize.called = True
+        return summary_text
+
+    fake_summarize.called = False
+    monkeypatch.setattr("scipreprocess.pipeline.summarize_caption", fake_summarize)
+
+    result = pipeline._summarize_figures(figures, use_summaries=True)
+
+    assert fake_summarize.called is True
+    assert result[0]["summary"] == summary_text
+
+
+def test_figure_summaries_disabled(monkeypatch):
+    """Ensure figure summaries are omitted when disabled."""
+
+    figures = [{"caption": "This figure shows a very detailed experiment.", "summary": "old"}]
+
+    def fake_summarize(caption: str) -> str:  # pragma: no cover - should not run
+        raise AssertionError("summarize_caption should not be called when disabled")
+
+    monkeypatch.setattr("scipreprocess.pipeline.summarize_caption", fake_summarize)
+
+    result = pipeline._summarize_figures(figures, use_summaries=False)
+
+    assert "summary" not in result[0]
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- add a configuration flag to control whether figure caption summaries are generated
- update the pipeline to skip figure summarization when disabled and document the new option
- add unit tests covering enabled and disabled figure summary behavior

## Testing
- pytest tests/test_pipeline.py