### PR TITLE
Add caption summarization fallbacks tests

### DIFF
--- a/src/scipreprocess/preprocessing.py
+++ b/src/scipreprocess/preprocessing.py
@@ -13,6 +13,9 @@ from .utils import cv2, nltk, pytesseract
 CITATION_PATTERN = re.compile(r"\(([A-Z][A-Za-z\-]+)( et al\.)?,\s*\d{4}[a-z]?\)")
 BRACKET_CITATION = re.compile(r"\[[0-9]{1,3}\]")
 
+# Default word budget for caption summaries
+CAPTION_SUMMARY_WORD_LIMIT = 60
+
 # NLTK resources
 STOPWORDS = set()
 WN = None
@@ -185,3 +188,35 @@ def sentence_split(text: str) -> list[str]:
         return [s.strip() for s in seg.segment(text) if s.strip()]
 
     return [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+
+
+def summarize_caption(caption: str, word_limit: int = CAPTION_SUMMARY_WORD_LIMIT) -> str:
+    """Summarize a figure or table caption while applying documented fallbacks."""
+
+    raw = caption.strip()
+    if not raw:
+        return ""
+
+    cleaned = clean_text(raw)
+    if not cleaned:
+        return ""
+
+    tokens = tokenize(cleaned)
+    if not tokens:
+        return cleaned
+
+    sentences = sentence_split(cleaned)
+    if len(sentences) == 1:
+        single = sentences[0].strip()
+        if not single:
+            return cleaned
+        words = [w for w in single.split() if w]
+        if len(words) <= word_limit:
+            return single
+        return " ".join(words[:word_limit]) + "…"
+
+    words = [w for w in cleaned.split() if w]
+    if len(words) <= word_limit:
+        return cleaned
+
+    return " ".join(words[:word_limit]) + "…"

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,0 +1,43 @@
+"""Edge-case tests for caption summarization fallbacks."""
+
+from scipreprocess.preprocessing import (
+    CAPTION_SUMMARY_WORD_LIMIT,
+    clean_text,
+    summarize_caption,
+)
+
+
+def test_summarize_caption_empty_returns_empty_string():
+    """Empty or whitespace captions should produce an empty summary."""
+
+    assert summarize_caption("") == ""
+    assert summarize_caption("   \n  ") == ""
+
+
+def test_summarize_caption_single_sentence_trimmed():
+    """A single sentence caption is returned as-is once trimmed."""
+
+    caption = "Single sentence caption with trailing spaces.   "
+    expected = "Single sentence caption with trailing spaces."
+
+    assert summarize_caption(caption) == expected
+
+
+def test_summarize_caption_truncates_when_over_word_limit():
+    """Captions exceeding the word limit are truncated with an ellipsis."""
+
+    words = [f"word{i}" for i in range(CAPTION_SUMMARY_WORD_LIMIT + 5)]
+    caption = " ".join(words)
+    expected = " ".join(words[:CAPTION_SUMMARY_WORD_LIMIT]) + "…"
+
+    assert summarize_caption(caption) == expected
+
+
+def test_summarize_caption_returns_cleaned_caption_when_tokenization_empty():
+    """If tokenization yields no tokens, fall back to the cleaned caption."""
+
+    caption = "  .??!  "
+    cleaned = clean_text(caption)
+
+    assert cleaned  # Guard to ensure fallback behaviour is exercised
+    assert summarize_caption(caption) == cleaned


### PR DESCRIPTION
## Summary
- add a summarize_caption helper with a configurable word budget and documented fallbacks
- cover the caption summarization fallbacks with dedicated unit tests

## Testing
- PYTHONPATH=src pytest -q
