### PR TITLE
Surface index metadata in pipeline output

### DIFF
--- a/src/scipreprocess/pipeline.py
+++ b/src/scipreprocess/pipeline.py
@@ -114,6 +114,7 @@ class PreprocessingPipeline:
         full_text: str,
         sections: list[dict[str, Any]],
         acronyms: dict[str, str],
+        index_info: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Assemble final document JSON structure.
 
@@ -138,14 +139,23 @@ class PreprocessingPipeline:
 
         figures = self._summarize_figures(parsed.metadata.get("figures", []))
 
+        metadata: dict[str, Any] = {
+            "title": title,
+            "source_file": parsed.source_path,
+            "pages": parsed.metadata.get("pages", None),
+            # Surface extracted authors if available
+            "authors": parsed.metadata.get("authors", []),
+        }
+
+        toc_entries = parsed.metadata.get("toc")
+        if toc_entries:
+            metadata["toc"] = toc_entries
+
+        if index_info:
+            metadata["index"] = index_info
+
         return {
-            "metadata": {
-                "title": title,
-                "source_file": parsed.source_path,
-                "pages": parsed.metadata.get("pages", None),
-                # Surface extracted authors if available
-                "authors": parsed.metadata.get("authors", []),
-            },
+            "metadata": metadata,
             "abstract": abstract,
             "sections": sections,
             "figures": figures,
@@ -229,7 +239,13 @@ class PreprocessingPipeline:
             )
 
         # Assemble final JSON
-        doc_json = self._assemble_document_json(parsed, expanded, sections, acr_map)
+        doc_json = self._assemble_document_json(
+            parsed,
+            expanded,
+            sections,
+            acr_map,
+            index_info,
+        )
 
         # Return JSON and combined section text
         section_text = " ".join(sec["text"] for sec in sections)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -119,5 +119,69 @@ def test_pipeline_figures_summary():
     assert len(summary.split()) <= 60, "Summaries should be length constrained"
 
 
+def test_pipeline_preserves_structured_index(monkeypatch):
+    """Structured TOC/index entries should surface in the final payload."""
+
+    config = PipelineConfig(use_spacy=False)
+    pipe = PreprocessingPipeline(config)
+
+    synthetic_toc = [
+        {"id": "1", "parent_id": None, "name": "Introduction", "page": "1"},
+        {"id": "1.1", "parent_id": "1", "name": "Background", "page": "2"},
+    ]
+
+    parsed = ParsedDocument(
+        source_path="dummy.pdf",
+        is_scanned=False,
+        text_pages=[
+            (
+                "Table of Contents\n"
+                "1 Introduction 1\n"
+                "1.1 Background 2\n\n"
+                "List of Figures\n"
+                "1 System Overview 5\n\n"
+                "Introduction\n"
+                "Main body text."
+            )
+        ],
+        images=[],
+        metadata={"toc": synthetic_toc},
+    )
+
+    sections = [
+        {
+            "heading": "Table of Contents",
+            "text": "1 Introduction 1\n1.1 Background 2\n",
+        },
+        {"heading": "List of Figures", "text": "1 System Overview 5\n"},
+        {"heading": "Introduction", "text": "Main body text."},
+    ]
+
+    monkeypatch.setattr(
+        pipeline,
+        "ingest",
+        lambda file_path, use_ocr, use_layout: parsed,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "split_into_sections_with_toc",
+        lambda full_text, toc: sections,
+    )
+    monkeypatch.setattr(pipeline, "split_into_sections", lambda full_text: sections)
+
+    doc_json, _ = pipe.preprocess_file("dummy.pdf")
+
+    metadata = doc_json["metadata"]
+    assert metadata.get("toc") == synthetic_toc
+
+    index_block = metadata.get("index", {})
+    assert index_block, "Index metadata should be populated"
+    toc_structured = index_block.get("toc_structured", [])
+    assert toc_structured and toc_structured[0]["name"] == "Introduction"
+
+    figures_list = index_block.get("list_of_figures", [])
+    assert figures_list and figures_list[0]["title"] == "System Overview"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- retain structured index details collected during preprocessing and surface them in the document metadata
- include available table-of-contents entries and extracted index artifacts when assembling the JSON payload
- add a regression test that exercises the pipeline end-to-end with synthetic TOC and index sections

## Testing
- pytest tests/test_pipeline.py::test_pipeline_preserves_structured_index -q
