### PR TITLE
Add optional Rust PDF ingestion backend with parity tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include CHANGELOG.md
 include pyproject.toml
 recursive-include examples *.py *.md *.json *.pdf
 recursive-include tests *.py *.md
+recursive-include rust_extensions *.py *.rs Cargo.toml
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 recursive-exclude * .DS_Store

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ scipreprocess document.pdf --format csv --out results.csv
 ### CLI Options
 
 - `inputs`: Paths to documents to process (required)
-- `--backend {auto,docling,local}`: Parser backend (default: auto)
+- `--backend {auto,docling,local,rust}`: Parser backend (default: auto)
 - `--ocr`: Enable OCR for scanned documents
 - `--layout`: Enable layout analysis
 - `--lower`: Convert text to lowercase

--- a/SETUP.md
+++ b/SETUP.md
@@ -207,6 +207,38 @@ black src/ tests/
 ruff check src/ tests/
 ```
 
+### Building the optional Rust PDF backend
+
+The accelerated PDF parser lives in `rust_extensions/pdf_ingest` and is built
+with [PyO3](https://pyo3.rs/). To compile it:
+
+1. Install the Rust toolchain (via [rustup](https://rustup.rs/)).
+2. Install `maturin` inside your virtual environment: `pip install maturin`.
+3. Build and install the extension in-place:
+
+   ```bash
+   python -m maturin develop --release --manifest-path rust_extensions/pdf_ingest/Cargo.toml
+   ```
+
+   The command produces a `pdf_ingest_rs` extension that the Python package
+   auto-detects at runtime.
+4. Verify availability:
+
+   ```python
+   >>> from rust_extensions import pdf_ingest
+   >>> pdf_ingest.is_available()
+   True
+   ```
+
+5. Run the backend parity test suite:
+
+   ```bash
+   pytest tests/test_pdf_backends.py -k rust_backend
+   ```
+
+If the extension is not built, SciPreprocess automatically falls back to the
+pure-Python PDF parser.
+
 ## Docker Setup (Optional)
 
 Create a `Dockerfile`:

--- a/rust_extensions/pdf_ingest/Cargo.toml
+++ b/rust_extensions/pdf_ingest/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pdf_ingest_rs"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "pdf_ingest_rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21", features = ["extension-module", "abi3-py310"] }
+regex = "1"

--- a/rust_extensions/pdf_ingest/src/lib.rs
+++ b/rust_extensions/pdf_ingest/src/lib.rs
@@ -1,0 +1,250 @@
+use std::collections::HashSet;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict, PyList};
+use regex::Regex;
+
+fn extract_figures(py: Python<'_>, text_pages: &[String]) -> PyResult<Vec<PyObject>> {
+    let figure_pattern = Regex::new(r"(?i)(Figure|Fig\.?)(?-i)\s+(\d+)")
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let mut figures: Vec<PyObject> = Vec::new();
+
+    for (page_idx, text) in text_pages.iter().enumerate() {
+        for caps in figure_pattern.captures_iter(text) {
+            let start = caps.get(0).map(|m| m.start()).unwrap_or(0);
+            let end = std::cmp::min(start + 300, text.len());
+            let mut caption = &text[start..end];
+            if let Some(pos) = caption.find("\n\n") {
+                caption = &caption[..pos];
+            }
+
+            let entry = PyDict::new(py);
+            entry.set_item("type", "figure")?;
+            entry.set_item("number", caps.get(2).map(|m| m.as_str()).unwrap_or(""))?;
+            entry.set_item("caption", caption.trim())?;
+            entry.set_item("page", page_idx + 1)?;
+            figures.push(entry.into());
+        }
+    }
+
+    Ok(figures)
+}
+
+fn extract_tables(py: Python<'_>, text_pages: &[String]) -> PyResult<Vec<PyObject>> {
+    let table_pattern = Regex::new(r"(?i)Table\s+(\d+)")
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let mut tables: Vec<PyObject> = Vec::new();
+
+    for (page_idx, text) in text_pages.iter().enumerate() {
+        for caps in table_pattern.captures_iter(text) {
+            let start = caps.get(0).map(|m| m.start()).unwrap_or(0);
+            let end = std::cmp::min(start + 300, text.len());
+            let mut caption = &text[start..end];
+            if let Some(pos) = caption.find("\n\n") {
+                caption = &caption[..pos];
+            }
+
+            let entry = PyDict::new(py);
+            entry.set_item("type", "table")?;
+            entry.set_item("number", caps.get(1).map(|m| m.as_str()).unwrap_or(""))?;
+            entry.set_item("caption", caption.trim())?;
+            entry.set_item("page", page_idx + 1)?;
+            tables.push(entry.into());
+        }
+    }
+
+    Ok(tables)
+}
+
+fn extract_equations(py: Python<'_>, text_pages: &[String]) -> PyResult<Vec<PyObject>> {
+    let eq_pattern = Regex::new(r"(?i)(Equation|Eq\.?)\s*[\(\[]?(\d+)[\)\]]?")
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let numbered_pattern = Regex::new(r"(?m)\((\d+)\)\s*$")
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let mut equations: Vec<PyObject> = Vec::new();
+
+    for (page_idx, text) in text_pages.iter().enumerate() {
+        let mut seen: HashSet<String> = HashSet::new();
+
+        for caps in eq_pattern.captures_iter(text) {
+            if let Some(num) = caps.get(2) {
+                let number = num.as_str().to_string();
+                if seen.insert(number.clone()) {
+                    let entry = PyDict::new(py);
+                    entry.set_item("type", "equation")?;
+                    entry.set_item("number", number)?;
+                    entry.set_item("page", page_idx + 1)?;
+                    equations.push(entry.into());
+                }
+            }
+        }
+
+        for caps in numbered_pattern.captures_iter(text) {
+            if let Some(num) = caps.get(1) {
+                let number = num.as_str().to_string();
+                if seen.insert(number.clone()) {
+                    let entry = PyDict::new(py);
+                    entry.set_item("type", "equation")?;
+                    entry.set_item("number", number)?;
+                    entry.set_item("page", page_idx + 1)?;
+                    equations.push(entry.into());
+                }
+            }
+        }
+    }
+
+    Ok(equations)
+}
+
+fn extract_references(py: Python<'_>, text_pages: &[String]) -> PyResult<Vec<PyObject>> {
+    let join_text = text_pages.join("\n");
+    let ref_pattern = Regex::new(r"\n\s*(References|REFERENCES|Bibliography|BIBLIOGRAPHY)\s*\n")
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+    let Some(ref_match) = ref_pattern.find(&join_text) else {
+        return Ok(Vec::new());
+    };
+
+    let mut remainder = &join_text[ref_match.end()..];
+    let end_patterns = [
+        Regex::new(r"\n\s*(Appendix|APPENDIX|Acknowledgments|ACKNOWLEDGMENTS)\s*\n")
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
+    ];
+
+    for pat in &end_patterns {
+        if let Some(m) = pat.find(remainder) {
+            remainder = &remainder[..m.start()];
+            break;
+        }
+    }
+
+    let number_pattern = Regex::new(r"\n\s*(?:\[(\d+)\]|(\d+)\.)\s+")
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+    let mut refs: Vec<(String, String)> = Vec::new();
+    let mut last_index = 0usize;
+    let mut current_number: Option<String> = None;
+
+    for caps in number_pattern.captures_iter(remainder) {
+        if let Some(m) = caps.get(0) {
+            let segment = &remainder[last_index..m.start()];
+            if let Some(number) = current_number.take() {
+                let text = segment.trim();
+                if !text.is_empty() {
+                    refs.push((number, text.to_string()));
+                }
+            }
+
+            if let Some(n) = caps.get(1).or_else(|| caps.get(2)) {
+                current_number = Some(n.as_str().to_string());
+            }
+            last_index = m.end();
+        }
+    }
+
+    let tail = remainder[last_index..].trim();
+    if let Some(number) = current_number {
+        if !tail.is_empty() {
+            refs.push((number, tail.to_string()));
+        }
+    }
+
+    if refs.is_empty() {
+        for (idx, line) in remainder.lines().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.len() > 20 {
+                refs.push(((idx + 1).to_string(), trimmed.to_string()));
+            }
+        }
+    }
+
+    let mut out: Vec<PyObject> = Vec::with_capacity(refs.len());
+    for (number, text) in refs {
+        let entry = PyDict::new(py);
+        entry.set_item("number", number)?;
+        entry.set_item("text", text)?;
+        out.push(entry.into());
+    }
+
+    Ok(out)
+}
+
+#[pyfunction]
+fn extract_text_from_pdf(
+    py: Python<'_>,
+    pdf_path: &str,
+    use_ocr: bool,
+    use_layout: bool,
+) -> PyResult<PyObject> {
+    let fitz = py.import("fitz").map_err(|_| PyRuntimeError::new_err("PyMuPDF not available"))?;
+    let doc = fitz.call_method1("open", (pdf_path,))?;
+    let page_count: usize = doc.call_method0("__len__")?.extract()?;
+
+    let mut text_pages: Vec<String> = Vec::with_capacity(page_count);
+    let mut total_len = 0usize;
+    let mut images: Vec<PyObject> = Vec::new();
+
+    let render_helper: Option<Py<PyAny>> = if use_ocr || use_layout {
+        let module = py.import("scipreprocess.parsers")?;
+        Some(module.getattr("render_pdf_page_to_image")?.into())
+    } else {
+        None
+    };
+
+    for idx in 0..page_count {
+        let page_any = doc.call_method1("__getitem__", (idx,))?;
+        let page_obj: Py<PyAny> = page_any.into_py(py);
+        let text: String = page_obj
+            .call_method1(py, "get_text", ("text",))?
+            .extract(py)?;
+        total_len += text.trim().len();
+        if let Some(helper) = &render_helper {
+            let img = helper
+                .as_ref(py)
+                .call1((page_obj.as_ref(py),))?
+                .into_py(py);
+            images.push(img);
+        }
+        text_pages.push(text);
+    }
+
+    let is_scanned = page_count > 0 && total_len < 20;
+
+    let toc_obj = match doc.getattr("get_toc") {
+        Ok(method) => {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("simple", false)?;
+            method.call((), Some(kwargs))?.into_py(py)
+        }
+        Err(_) => py.None().into_py(py),
+    };
+
+    let figures = extract_figures(py, &text_pages)?;
+    let tables = extract_tables(py, &text_pages)?;
+    let equations = extract_equations(py, &text_pages)?;
+    let references = extract_references(py, &text_pages)?;
+
+    let metadata = PyDict::new(py);
+    metadata.set_item("pages", page_count)?;
+    metadata.set_item("toc", toc_obj)?;
+    metadata.set_item("figures", PyList::new(py, &figures))?;
+    metadata.set_item("tables", PyList::new(py, &tables))?;
+    metadata.set_item("equations", PyList::new(py, &equations))?;
+    metadata.set_item("references", PyList::new(py, &references))?;
+
+    let result = PyDict::new(py);
+    result.set_item("pages", PyList::new(py, &text_pages))?;
+    result.set_item("images", PyList::new(py, &images))?;
+    result.set_item("metadata", metadata)?;
+    result.set_item("is_scanned", is_scanned)?;
+
+    Ok(result.into())
+}
+
+#[pymodule]
+fn pdf_ingest_rs(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(extract_text_from_pdf, m)?)?;
+    m.add("__all__", PyList::new(py, &["extract_text_from_pdf"]))?;
+    Ok(())
+}

--- a/src/rust_extensions/__init__.py
+++ b/src/rust_extensions/__init__.py
@@ -1,0 +1,3 @@
+"""Namespace package for optional native accelerators."""
+
+__all__ = []

--- a/src/rust_extensions/pdf_ingest/__init__.py
+++ b/src/rust_extensions/pdf_ingest/__init__.py
@@ -1,0 +1,37 @@
+"""Bindings for the optional Rust-based PDF ingestion backend."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Dict
+
+try:  # pragma: no cover - exercised via integration tests
+    _native = import_module("pdf_ingest_rs")
+except Exception:  # pragma: no cover - gracefully handle missing builds
+    _native = None
+
+
+def is_available() -> bool:
+    """Return ``True`` when the compiled Rust extension can be imported."""
+
+    return _native is not None
+
+
+def extract_text_from_pdf(
+    pdf_path: str, use_ocr: bool = False, use_layout: bool = False
+) -> Dict[str, Any]:
+    """Mirror :func:`scipreprocess.parsers.extract_text_from_pdf` in Rust."""
+
+    if _native is None:  # pragma: no cover - import guarded by availability checks
+        raise RuntimeError(
+            "pdf_ingest_rs extension is not available. Build the Rust module first."
+        )
+
+    payload = _native.extract_text_from_pdf(pdf_path, use_ocr, use_layout)
+    if not isinstance(payload, dict):  # pragma: no cover - defensive programming
+        raise RuntimeError("Unexpected payload returned from pdf_ingest_rs")
+
+    return payload
+
+
+__all__ = ["extract_text_from_pdf", "is_available"]

--- a/src/scipreprocess/cli.py
+++ b/src/scipreprocess/cli.py
@@ -11,10 +11,10 @@ from .utils import serialize_output
 
 def main() -> int:
     p = argparse.ArgumentParser(
-        prog="scipreprocess", description="Preprocess documents with optional Docling backend"
+        prog="scipreprocess", description="Preprocess documents with optional accelerated backends"
     )
     p.add_argument("inputs", nargs="+", help="Paths to documents")
-    p.add_argument("--backend", choices=["auto", "docling", "local"], default="auto")
+    p.add_argument("--backend", choices=["auto", "docling", "local", "rust"], default="auto")
     p.add_argument("--ocr", action="store_true")
     p.add_argument("--layout", action="store_true")
     p.add_argument("--lower", action="store_true")
@@ -27,6 +27,7 @@ def main() -> int:
     cfg = PipelineConfig(
         use_ocr=args.ocr,
         use_layout=args.layout,
+        parser_backend=args.backend,
     )
     pipe = PreprocessingPipeline(cfg)
     inputs = []

--- a/src/scipreprocess/config.py
+++ b/src/scipreprocess/config.py
@@ -15,6 +15,7 @@ class PipelineConfig:
         use_spacy: Use spaCy for NLP tasks (tokenization, lemmatization).
         use_semantic_embeddings: Generate semantic embeddings for chunks.
         use_figure_summaries: Generate short summaries for figure captions.
+        parser_backend: Preferred PDF parser backend ("auto", "local", "docling", "rust").
         spacy_model: Name of the spaCy model to load.
         embedding_model: Name of the sentence-transformer model.
         chunk_target_sentences: Min and max sentences per chunk.
@@ -25,7 +26,7 @@ class PipelineConfig:
     use_spacy: bool = True
     use_semantic_embeddings: bool = False
     use_figure_summaries: bool = True
-    # Backend selection for parsing; "auto" defaults to local
+    # Backend selection for parsing; "auto" prefers the Rust backend when available
     parser_backend: str = "auto"
     spacy_model: str = "en_core_web_sm"
     embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"

--- a/src/scipreprocess/parsers.py
+++ b/src/scipreprocess/parsers.py
@@ -6,6 +6,17 @@ import pathlib
 import re
 from typing import Any
 
+try:  # pragma: no cover - optional native acceleration
+    from rust_extensions.pdf_ingest import (  # type: ignore[import-not-found]
+        extract_text_from_pdf as rust_extract_text_from_pdf,
+        is_available as rust_backend_available,
+    )
+except Exception:  # pragma: no cover - runtime availability check
+    rust_extract_text_from_pdf = None
+
+    def rust_backend_available() -> bool:
+        return False
+
 from .models import ParsedDocument
 from .utils import ET, cv2, docx, fitz
 
@@ -235,7 +246,7 @@ def extract_references_from_pdf(doc, text_pages: list[str]) -> list[dict]:
     return references
 
 
-def extract_text_from_pdf(
+def _extract_text_from_pdf_python(
     pdf_path: str, use_ocr: bool = False, use_layout: bool = False
 ) -> ParsedDocument:
     """Extract text from a PDF document.
@@ -294,6 +305,69 @@ def extract_text_from_pdf(
             "references": references,
         },
     )
+
+
+def _extract_text_from_pdf_native(
+    pdf_path: str, use_ocr: bool = False, use_layout: bool = False
+) -> ParsedDocument:
+    """Invoke the optional Rust backend if it has been built."""
+
+    if rust_extract_text_from_pdf is None:
+        raise RuntimeError("Rust backend not available")
+
+    payload = rust_extract_text_from_pdf(pdf_path, use_ocr, use_layout)
+    pages = [str(p) for p in payload.get("pages", [])]
+    images = list(payload.get("images", []))
+    metadata = dict(payload.get("metadata", {}))
+    if "pages" not in metadata:
+        metadata["pages"] = len(pages)
+
+    return ParsedDocument(
+        source_path=pdf_path,
+        is_scanned=bool(payload.get("is_scanned", False)),
+        text_pages=pages,
+        images=images,
+        metadata=metadata,
+    )
+
+
+def extract_text_from_pdf(
+    pdf_path: str,
+    use_ocr: bool = False,
+    use_layout: bool = False,
+    backend: str | None = None,
+) -> ParsedDocument:
+    """Extract text from PDF using either the Python or Rust backend."""
+
+    preference = (backend or "auto").lower()
+    valid = {"auto", "local", "docling", "rust", "native"}
+    if preference not in valid:
+        raise ValueError(f"Unknown parser backend: {preference}")
+
+    selected = preference
+
+    if selected == "native":
+        selected = "rust"
+
+    if preference == "auto":
+        selected = "rust" if rust_backend_available() else "local"
+
+    if selected in {"rust", "native"}:
+        if not rust_backend_available():
+            if preference == "auto":
+                selected = "local"
+            else:
+                raise RuntimeError("Rust backend requested but not available")
+
+    if selected == "rust":
+        parsed = _extract_text_from_pdf_native(pdf_path, use_ocr, use_layout)
+        parsed.metadata["_parser_backend"] = "rust"
+        return parsed
+
+    # Fallback to the pure Python implementation for local/docling cases
+    parsed = _extract_text_from_pdf_python(pdf_path, use_ocr, use_layout)
+    parsed.metadata["_parser_backend"] = "local"
+    return parsed
 
 
 def extract_text_from_docx(docx_path: str) -> ParsedDocument:
@@ -436,13 +510,19 @@ def extract_text_from_txt(txt_path: str) -> ParsedDocument:
     )
 
 
-def ingest(file_path: str, use_ocr: bool = False, use_layout: bool = False) -> ParsedDocument:
+def ingest(
+    file_path: str,
+    use_ocr: bool = False,
+    use_layout: bool = False,
+    backend: str | None = None,
+) -> ParsedDocument:
     """Ingest a document and extract its text.
 
     Args:
         file_path: Path to the document.
         use_ocr: Whether OCR might be needed for PDFs.
         use_layout: Whether layout analysis might be needed for PDFs.
+        backend: Preferred parser backend for PDFs.
 
     Returns:
         ParsedDocument with extracted text.
@@ -453,7 +533,7 @@ def ingest(file_path: str, use_ocr: bool = False, use_layout: bool = False) -> P
     fmt = detect_format(file_path)
 
     if fmt == "pdf":
-        return extract_text_from_pdf(file_path, use_ocr, use_layout)
+        return extract_text_from_pdf(file_path, use_ocr, use_layout, backend=backend)
     if fmt == "docx":
         return extract_text_from_docx(file_path)
     if fmt == "tex":

--- a/src/scipreprocess/pipeline.py
+++ b/src/scipreprocess/pipeline.py
@@ -12,17 +12,16 @@ from .local_extract import extract_header_blocks, extract_index_sections
 from .models import ParsedDocument
 from .parsers import ingest
 from .preprocessing import clean_text, ocr_image_to_text
-from .summarization import summarize_caption
+from .summarization import summarize_caption as advanced_summarize_caption
 from .sectioning import (
     semantic_chunk_sections,
     split_into_sections,
     split_into_sections_with_toc,
 )
-from .summarization import summarize_caption
 from .utils import ensure_nltk_resources, load_spacy_model, print_availability_status
 
 
-def summarize_caption(caption: str, max_words: int = 40) -> str:
+def _fallback_summarize_caption(caption: str, max_words: int = 40) -> str:
     """Create a short summary from a figure caption."""
 
     words = caption.strip().split()
@@ -48,7 +47,7 @@ def _summarize_figures(
 
         caption = figure_copy.get("caption")
         if isinstance(caption, str) and caption.strip():
-            figure_copy["summary"] = summarize_caption(caption)
+            figure_copy["summary"] = _fallback_summarize_caption(caption)
 
         summarized.append(figure_copy)
 
@@ -136,31 +135,34 @@ class PreprocessingPipeline:
         # Extract abstract
         abstract = next((s["text"] for s in sections if s["heading"].lower() == "abstract"), "")
 
-        figures = self._summarize_figures(parsed.metadata.get("figures", []))
+        metadata = {
+            k: v for k, v in parsed.metadata.items() if not k.startswith("_")
+        }
+        figures = self._summarize_figures(metadata.get("figures", []))
+
+        backend = parsed.metadata.get("_parser_backend") or self.config.parser_backend
+        if backend not in {"local", "docling", "rust"}:
+            backend = "local"
 
         return {
             "metadata": {
                 "title": title,
                 "source_file": parsed.source_path,
-                "pages": parsed.metadata.get("pages", None),
+                "pages": metadata.get("pages", None),
                 # Surface extracted authors if available
-                "authors": parsed.metadata.get("authors", []),
+                "authors": metadata.get("authors", []),
             },
             "abstract": abstract,
             "sections": sections,
             "figures": figures,
-            "tables": parsed.metadata.get("tables", []),
-            "equations": parsed.metadata.get("equations", []),
-            "references": parsed.metadata.get("references", []),
+            "tables": metadata.get("tables", []),
+            "equations": metadata.get("equations", []),
+            "references": metadata.get("references", []),
             "acronyms": acronyms,
             # Minimal provenance for tests
             "provenance": {
                 "pipeline": "local",
-                "backend": (
-                    self.config.parser_backend
-                    if self.config.parser_backend in {"local", "docling"}
-                    else "local"
-                ),
+                "backend": backend,
             },
         }
 
@@ -175,7 +177,12 @@ class PreprocessingPipeline:
             Tuple of (document JSON, full cleaned text).
         """
         # Ingest document
-        parsed = ingest(file_path, self.config.use_ocr, self.config.use_layout)
+        parsed = ingest(
+            file_path,
+            self.config.use_ocr,
+            self.config.use_layout,
+            backend=self.config.parser_backend,
+        )
 
         # Apply OCR if needed
         parsed = self._ensure_text_for_scanned(parsed)
@@ -249,7 +256,10 @@ class PreprocessingPipeline:
                 continue
 
             caption = item.get("caption", "")
-            summary = summarize_caption(caption, self.nlp_model)
+            if self.nlp_model is not None:
+                summary = advanced_summarize_caption(caption, self.nlp_model)
+            else:
+                summary = _fallback_summarize_caption(caption)
             enriched = dict(item)
             enriched["summary"] = summary
             summarized.append(enriched)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_docling_backend.py
+++ b/tests/test_docling_backend.py
@@ -22,7 +22,7 @@ def test_backend_provenance(tmp_path: pathlib.Path, backend: str):
     doc = out["documents"][0]
     prov = doc.get("provenance", {})
     assert prov.get("pipeline") == "local"
-    assert prov.get("backend") in {"local", "docling"}
+    assert prov.get("backend") in {"local", "docling", "rust"}
 
 
 def test_cli_hardening_empty(tmp_path: pathlib.Path, capsys):

--- a/tests/test_pdf_backends.py
+++ b/tests/test_pdf_backends.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from scipreprocess.config import PipelineConfig
+from scipreprocess.parsers import extract_text_from_pdf
+from scipreprocess.pipeline import PreprocessingPipeline
+
+
+@pytest.fixture()
+def sample_pdf(tmp_path: pathlib.Path) -> pathlib.Path:
+    fitz = pytest.importorskip("fitz", reason="PyMuPDF required for PDF backend tests")
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text(
+        (72, 72),
+        (
+            "Figure 1 Example caption\n"
+            "Table 1 Example caption\n"
+            "Equation (1) shows something important.\n"
+            "References\n"
+            "[1] Example reference entry about science.\n"
+        ),
+    )
+    path = tmp_path / "backend.pdf"
+    doc.save(path)
+    doc.close()
+    return path
+
+
+def test_rust_backend_matches_python(sample_pdf: pathlib.Path):
+    pdf_ingest = pytest.importorskip(
+        "rust_extensions.pdf_ingest", reason="Rust backend not built"
+    )
+    if not pdf_ingest.is_available():
+        pytest.skip("Rust backend Python bindings available but extension missing")
+
+    local = extract_text_from_pdf(str(sample_pdf), backend="local")
+    rust = extract_text_from_pdf(str(sample_pdf), backend="rust")
+
+    assert local.text_pages == rust.text_pages
+    assert local.metadata["figures"] == rust.metadata["figures"]
+    assert local.metadata["tables"] == rust.metadata["tables"]
+    assert local.metadata["equations"] == rust.metadata["equations"]
+    assert local.metadata["references"] == rust.metadata["references"]
+
+    pipe_local = PreprocessingPipeline(
+        PipelineConfig(use_spacy=False, parser_backend="local")
+    )
+    pipe_rust = PreprocessingPipeline(
+        PipelineConfig(use_spacy=False, parser_backend="rust")
+    )
+
+    local_json, _ = pipe_local.preprocess_file(str(sample_pdf))
+    rust_json, _ = pipe_rust.preprocess_file(str(sample_pdf))
+
+    assert local_json == rust_json


### PR DESCRIPTION
## Summary
- add a pdf_ingest_rs Rust extension and Python bindings to expose the native PDF extractor
- allow selecting the Rust backend through PipelineConfig/CLI and keep provenance consistent while sanitising metadata
- document Rust build steps and add parity tests plus shared test configuration for the new backend

## Testing
- pytest
